### PR TITLE
Fix typo - issest() should be isset()

### DIFF
--- a/views/templates/hook/crossselling.tpl
+++ b/views/templates/hook/crossselling.tpl
@@ -42,7 +42,7 @@
 					{else}
 						<br />
 					{/if}
-					{if issest($orderProduct.description_short)}<p>{$orderProduct.description_short|strip_tags:'UTF-8'|truncate:50:'...'}</p>{/if}
+					{if isset($orderProduct.description_short)}<p>{$orderProduct.description_short|strip_tags:'UTF-8'|truncate:50:'...'}</p>{/if}
 					<!-- <a title="{l s='View' mod='crossselling'}" href="{$orderProduct.link}" class="button_small">{l s='View' mod='crossselling'}</a><br /> -->
 				</li>
 				{/foreach}


### PR DESCRIPTION
Noticed this when this popped up in our error_log for one of our clients:

````
[Tue Aug 18 14:00:39 2015] [error] [client X.X.X.X] PHP Fatal error:  Uncaught  --> Smarty Compiler: Syntax error in template "/var/www/html/modules/crossselling/views/templates/hook/crossselling.tpl"  on line 45 "{if issest($orderProduct.description_short)}<p>{$orderProduct.description_short|strip_tags:'UTF-8'|truncate:50:'...'}</p>{/if}" unknown function "issest" <-- \n  thrown in /var/www/html/tools/smarty/sysplugins/smarty_internal_templatecompilerbase.php on line 45
````